### PR TITLE
Llvm toml file

### DIFF
--- a/battery.toml
+++ b/battery.toml
@@ -1,2 +1,2 @@
 name = "battery"
-dependencies = ["battery.lib"]
+dependencies = ["battery.lib", "watt.toml"]

--- a/doc/index.md
+++ b/doc/index.md
@@ -258,3 +258,14 @@ warningsEnabled		Tells the Volta compiler to generate warnings. (boolean)
 ```
 
 Platform identifiers can be simple: `[platform.msvc]`. The second part can be a string: `[platform.'msvc']`. You can `&&` or `||` platforms, as well `!`ing them: `[platform.'!msvc && !macOS]`.
+
+### llvm.toml
+
+```
+llvmVersion="7.0.0"
+clangPath="C:/Path/To/Clang.exe"
+```
+
+This file format is mostly intended for Windows systems where `llvm-conf` can't be used. Use `--llvmconf` with `config` on the command line, or use the `llvmConf` key to specify it.
+
+`llvmVersion` specifies the version in [semantic versioning](https://semver.org/). `clangPath` specifies the path to the clang executable to use.

--- a/src/battery/driver.volt
+++ b/src/battery/driver.volt
@@ -518,6 +518,7 @@ before doing anything else.
 		info("\t--cmd command    Run the command and processes output as arguments.");
 		info("\t-l lib           Add a library.");
 		info("\t-L path          Add a library path.");
+		info("\t--llvmconf       Add path to a llvm configuration file.");
 		version (OSX) {
 		info("\t-framework name  Add a framework.");
 		info("\t-F path          Add a framework search path.");

--- a/src/battery/frontend/conf.volt
+++ b/src/battery/frontend/conf.volt
@@ -5,10 +5,15 @@
  */
 module battery.frontend.conf;
 
+import io = watt.io;
 import file = watt.io.file;
 import toml = watt.toml;
+import wpath = watt.path;
 import text = [watt.text.string, watt.text.ascii, watt.text.path, watt.process.cmd];
 import process = watt.process.pipe;
+import semver = watt.text.semver;
+
+import llvmConf = battery.frontend.llvmConf;
 
 import battery.configuration;
 
@@ -86,7 +91,8 @@ fn verifyKeys(root: toml.Value, tomlPath: string, d: Driver)
 		case DependenciesKey, PlatformTable, NameKey, OutputKey, ScanForDKey, IsTheRTKey,
 			SrcDirKey, TestFilesKey, JsonOutputKey, LibsKey, LPathsKey, FrameworksKey, FPathsKey,
 			StringPathKey, LDArgsKey, CCArgsKey, LinkArgsKey, LinkerArgsKey,
-			AsmFilesKey, CFilesKey, ObjFilesKey, VoltFilesKey, IdentKey, CommandKey, WarningKey:
+			AsmFilesKey, CFilesKey, ObjFilesKey, VoltFilesKey, IdentKey, CommandKey, WarningKey,
+			LlvmConfig:
 			continue;
 		default:
 			d.info(new "Warning: unknown key '${key}' in config file '${tomlPath}'");
@@ -120,6 +126,7 @@ enum VoltFilesKey    = "voltFiles";
 enum IdentKey        = "versionIdentifiers";
 enum CommandKey      = "commands";
 enum WarningKey      = "warningsEnabled";
+enum LlvmConfig      = "llvmConfig";
 
 fn parseCommand(cmd: string, c: Configuration, b: Project)
 {

--- a/src/battery/frontend/llvmConf.volt
+++ b/src/battery/frontend/llvmConf.volt
@@ -1,0 +1,99 @@
+// Copyright © 2018, Bernard Helyer.  All rights reserved.
+// See copyright notice in src/battery/license.volt (BOOST ver. 1.0).
+/*!
+ * Code for handling a small config file that declares information regarding LLVM.
+ *
+ * This is for building the compiler on Windows systems, where we can't use
+ * `llvm-config`.
+ */
+module battery.frontend.llvmConf;
+
+import battery.interfaces;
+import     io = watt.io;
+import   toml = watt.toml;
+import getopt = watt.text.getopt;
+import semver = watt.text.semver;
+import   file = watt.io.file;
+import   path = [watt.path, watt.text.path];
+
+enum DefaultLlvmTomlName = "llvm.toml";
+
+fn scan(args: string[]) bool
+{
+	foreach (arg; args) {
+		if (arg[0] == '-') {
+			continue;
+		}
+		if (scan(arg)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+fn scan(fpath: string) bool
+{
+	proposedPath := path.concatenatePath(fpath, DefaultLlvmTomlName);
+	if (file.exists(proposedPath)) {
+		parse(proposedPath);
+		return true;
+	}
+	return false;
+}
+
+/*!
+ * Parse llvmConf-related command line arguments.
+ *
+ * This parses the argument `--llvmconf` from `args`.
+ */
+fn parseArguments(ref args: string[])
+{
+	configPath: string;
+	if (getopt.getopt(ref args, "llvmconf", ref configPath)) {
+		parse(configPath);
+	}
+}
+
+@property fn parsed() bool
+{
+	return gParsed;
+}
+
+@property fn llvmVersion() semver.Release
+{
+	assert(gParsed);
+	return gLlvmVersion;
+}
+
+@property fn clangPath() string
+{
+	assert(gParsed);
+	return gClangPath;
+}
+
+/*!
+ * Given a path to a llvm.conf file, retrieve the contained values.
+ *
+ * The config file is a small [TOML](https://github.com/toml-lang/toml) file.
+ * `llvmVersion` is a [semver](https://semver.org/) string.
+ * `clangPath` is a string with a path to the clang executable.
+ *
+ * @Param confPath The path to the config file.
+ */
+fn parse(confPath: string)
+{
+	if (gParsed) {
+		return;
+	}
+	confStr := cast(string)file.read(confPath);
+	value   := toml.parse(confStr);
+	gLlvmVersion = new semver.Release(value["llvmVersion"].str());
+	gClangPath   = value["clangPath"].str();
+	gParsed = true;
+}
+
+private:
+
+global gParsed: bool;
+global gLlvmVersion: semver.Release;
+global gClangPath: string;

--- a/src/battery/frontend/llvmVersion.volt
+++ b/src/battery/frontend/llvmVersion.volt
@@ -1,0 +1,100 @@
+// Copyright © 2018, Bernard Helyer.  All rights reserved.
+// See copyright notice in src/battery/license.volt (BOOST ver. 1.0).
+/*!
+ * Functions for retrieving and processing the LLVM version.
+ */
+module battery.frontend.llvmVersion;
+
+import llvmConf = battery.frontend.llvmConf;
+import text     = watt.text.string;
+import semver   = watt.text.semver;
+import process  = watt.process;
+import battery  = [
+	battery.interfaces,
+	battery.configuration,
+	battery.policy.config,
+	battery.policy.tools,
+];
+
+enum IdentifierPrefix = "LlvmVersion";
+
+/*!
+ * Get the installed LLVM version from the system.
+ *
+ * @Returns The LLVM version or `null` if no LLVM could be detected.
+ */
+fn get(drv: battery.Driver) semver.Release
+{
+	if (!gCached) {
+		gReleaseCache = getImpl(drv);
+		gCached = true;
+	}
+	return gReleaseCache;
+}
+
+fn addVersionIdentifiers(drv: battery.Driver, prj: battery.Project) bool
+{
+	if (!text.startsWith(prj.name, "volta")) {
+		return false;
+	}
+	idents := identifiers(get(drv));
+	prj.defs ~= idents[..];
+	return true;
+}
+
+/*!
+ * Given an LLVM version, return a list of identifiers to set while
+ * compiling code.
+ *
+ * So if you pass a version of `3.9.1`, this function will return
+ * an array containing `LlvmVersion3`, `LlvmVersion3_9`, and `LlvmVersion3_9_1`,
+ * and the version of intrinsics used: LlvmIntrinsics1 (explicit alignment <= 6)
+ * or LlvmIntrinsics2 (>= 7).
+ */
+fn identifiers(ver: semver.Release) string[3]
+{
+	assert(ver !is null);
+	idents: string[3];
+	idents[0] = new "${IdentifierPrefix}${ver.major}";
+	idents[1] = new "${IdentifierPrefix}${ver.major}_${ver.minor}";
+	idents[2] = new "${IdentifierPrefix}${ver.major}_${ver.minor}_${ver.patch}";
+	return idents;
+}
+
+private:
+
+global gReleaseCache: semver.Release;
+global gCached: bool;
+
+fn getImpl(drv: battery.Driver) semver.Release
+{
+	version (Windows) {
+		if (llvmConf.parsed) {
+			return llvmConf.llvmVersion;
+		} else {
+			return null;
+		}
+	} else {
+		dummyConfig := new battery.Configuration();
+		dummyConfig.kind = battery.ConfigKind.Native;
+		dummyConfig.env = process.retrieveEnvironment();
+		battery.doToolChainLLVM(drv, dummyConfig, battery.UseAsLinker.NO, battery.Silent.YES);
+		configCmd := dummyConfig.getTool(battery.LLVMConfigName);
+		if (configCmd is null) {
+			return null;
+		}
+
+		configOutput: string;
+		configRetval: u32;
+		try {
+			configOutput = process.getOutput(configCmd.cmd, ["--version"], ref configRetval);
+		} catch (process.ProcessException e) {
+			return null;
+		}
+		configOutput = text.strip(configOutput);
+		if (configRetval != 0 || !semver.Release.isValid(configOutput)) {
+			return null;
+		}
+		return new semver.Release(configOutput);
+	}
+}

--- a/src/battery/frontend/parameters.volt
+++ b/src/battery/frontend/parameters.volt
@@ -388,6 +388,7 @@ protected:
 			case LibraryPath: lib.libPaths ~= arg.extra; break;
 			case Framework: lib.frameworks ~= arg.extra; break;
 			case FrameworkPath: lib.frameworkPaths ~= arg.extra; break;
+			case Identifier: lib.defs ~= arg.extra; break;
 			case StringPath: lib.stringPaths ~= arg.extra; break;
 			case ArgLD: lib.xld ~= arg.extra; break;
 			case ArgCC: lib.xcc ~= arg.extra; break;

--- a/src/battery/policy/config.volt
+++ b/src/battery/policy/config.volt
@@ -316,7 +316,14 @@ enum UseAsLinker
 	YES,
 }
 
-fn doToolChainLLVM(drv: Driver, config: Configuration, useLinker: UseAsLinker)
+enum Silent
+{
+	NO,
+	YES,
+}
+
+fn doToolChainLLVM(drv: Driver, config: Configuration, useLinker: UseAsLinker,
+	silent: Silent = Silent.NO)
 {
 	llvm7, llvm60, llvm50, llvm40, llvm39, llvm: LLVMConfig;
 	llvm.fillInFromDriver(drv, config);
@@ -338,13 +345,15 @@ fn doToolChainLLVM(drv: Driver, config: Configuration, useLinker: UseAsLinker)
 	} else if (llvm39.fillInFromPath(config, "-3.9")) {
 		llvm = llvm39;
 	} else {
-		llvm.printMissing();
-		llvm7.printMissing();
-		llvm60.printMissing();
-		llvm50.printMissing();
-		llvm40.printMissing();
-		llvm39.printMissing();
-		drv.abort("could not find a valid llvm toolchain");
+		if (!silent) {
+			llvm.printMissing();
+			llvm7.printMissing();
+			llvm60.printMissing();
+			llvm50.printMissing();
+			llvm40.printMissing();
+			llvm39.printMissing();
+			drv.abort("could not find a valid llvm toolchain");
+		}
 	}
 
 	if (llvm.config !is null && llvm.needConfig) {
@@ -401,6 +410,10 @@ fn doToolChainLLVM(drv: Driver, config: Configuration, useLinker: UseAsLinker)
 				linker.args ~= ["-flto=thin", "-fuse-ld=lld"];
 			}
 		}
+	}
+
+	if (silent) {
+		return;
 	}
 
 	drv.info("Using LLVM%s toolchain from %s.", llvm.suffix, llvm.drvAll ? "arguments" : "path");

--- a/src/battery/policy/config.volt
+++ b/src/battery/policy/config.volt
@@ -318,15 +318,17 @@ enum UseAsLinker
 
 fn doToolChainLLVM(drv: Driver, config: Configuration, useLinker: UseAsLinker)
 {
-	llvm60, llvm50, llvm40, llvm39, llvm: LLVMConfig;
+	llvm7, llvm60, llvm50, llvm40, llvm39, llvm: LLVMConfig;
 	llvm.fillInFromDriver(drv, config);
 
-	llvm60 = llvm50 = llvm40 = llvm39 = llvm;
+	llvm7 = llvm60 = llvm50 = llvm40 = llvm39 = llvm;
 
 	if (llvm.drvAll) {
 		// Nothing todo
 	} else if (llvm.fillInFromPath(config, null)) {
 		// Nothing todo
+	} else if (llvm7.fillInFromPath(config, "-7")) {
+		llvm = llvm7;
 	} else if (llvm60.fillInFromPath(config, "-6.0")) {
 		llvm = llvm60;
 	} else if (llvm50.fillInFromPath(config, "-5.0")) {
@@ -337,6 +339,7 @@ fn doToolChainLLVM(drv: Driver, config: Configuration, useLinker: UseAsLinker)
 		llvm = llvm39;
 	} else {
 		llvm.printMissing();
+		llvm7.printMissing();
 		llvm60.printMissing();
 		llvm50.printMissing();
 		llvm40.printMissing();

--- a/src/battery/policy/tools.volt
+++ b/src/battery/policy/tools.volt
@@ -10,6 +10,7 @@ import battery.interfaces;
 import battery.configuration;
 import battery.driver;
 import battery.util.path : searchPath;
+import llvmVersion = battery.frontend.llvmVersion;
 
 
 
@@ -232,6 +233,25 @@ fn addRdmdArgs(drv: Driver, config: Configuration, c: Command)
 	}
 }
 
+fn addLlvmVersionsToBootstrapCompiler(drv: Driver, c: Command)
+{
+	fn getVersionFlag(s: string) string
+	{
+		if (c.name == "rdmd") {
+			return new "-version=${s}";
+		} else if (c.name == "gdc") {
+			return new "-fversion=${s}";
+		} else {
+			assert(false, "unknown bootstrap compiler");
+		}
+	}
+
+	llvmVersions := llvmVersion.identifiers(llvmVersion.get(drv));
+	foreach (v; llvmVersions) {
+		c.args ~= getVersionFlag(v);
+	}
+}
+
 
 /*
  *
@@ -249,6 +269,11 @@ fn addGdcArgs(drv: Driver, config: Configuration, c: Command)
 	final switch (config.arch) with (Arch) {
 	case X86: c.args ~= "-m32"; break;
 	case X86_64: c.args ~= "-m64"; break;
+	}
+
+	llvmVersions := llvmVersion.identifiers(llvmVersion.get(drv));
+	foreach (v; llvmVersions) {
+		c.args ~= format("-fversion=%s", v);
 	}
 }
 

--- a/test/battery.tests.json
+++ b/test/battery.tests.json
@@ -1,0 +1,11 @@
+{
+	"pattern": "test.volt",
+	"testCommandPrefix": "//T ",
+	"macros": {
+		"default": [
+			"//T run:volta -o %t %s",
+			"//T run:%t"
+		]
+	}
+}
+

--- a/test/frontend/llvmVersion/simple/test.volt
+++ b/test/frontend/llvmVersion/simple/test.volt
@@ -1,0 +1,47 @@
+module test;
+
+import semver = watt.text.semver;
+import llvmVersion = battery.frontend.llvmVersion;
+
+global tests := [
+"6.0.0",
+"LlvmVersion6", "LlvmVersion6_0", "LlvmVersion6_0_0",
+"7.0.1",
+"LlvmVersion7", "LlvmVersion7_0", "LlvmVersion7_0_1",
+"3.9.0-svn",
+"LlvmVersion3", "LlvmVersion3_9", "LlvmVersion3_9_0",
+"1.2.3",
+"LlvmVersion1", "LlvmVersion1_2", "LlvmVersion1_2_3",
+"7.0.0",
+"LlvmVersion7", "LlvmVersion7_0", "LlvmVersion7_0_0",
+];
+
+fn pop() string
+{
+	if (tests.length == 0) {
+		return null;
+	}
+	val := tests[0];
+	tests = tests[1 .. $];
+	return val;
+}
+
+fn main() i32
+{
+	while (tests.length > 0) {
+		testVersionStr := pop();
+		if (!semver.Release.isValid(testVersionStr)) {
+			return 1;
+		}
+		testVersion := new semver.Release(testVersionStr);
+
+		a := llvmVersion.identifiers(testVersion);
+		b: string[3];
+		b[0] = pop(); b[1] = pop(); b[2] = pop();
+		if (a[..] != b[..]) {
+			return 2;
+		}
+	}
+	return 0;
+}
+


### PR DESCRIPTION
Handles a couple of things. First instance of piping LLVM version through battery (obviously no `llvm-conf` support for nix yet, that'll be a different commit), but more importantly adds the ability to manually set the LLVM version and path to the clang executable to use.