### PR TITLE
Add macOS aarch64 and LDC support

### DIFF
--- a/lib/src/battery/defines.volt
+++ b/lib/src/battery/defines.volt
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Jakob Bornecrantz.
+// Copyright 2016-2024, Jakob Bornecrantz.
 // SPDX-License-Identifier: BSL-1.0
 /*!
  * Common enums and classes, aka "defines".
@@ -108,6 +108,7 @@ struct BatteryConfig
 
 	gdcCmd: string;
 	rdmdCmd: string;
+	ldcCmd: string;
 
 	pkgs: string[];
 

--- a/lib/src/battery/detect/ldc.volt
+++ b/lib/src/battery/detect/ldc.volt
@@ -1,0 +1,273 @@
+// Copyright 2016-2024, Bernard Helyer.
+// Copyright 2016-2024, Jakob Bornecrantz.
+// SPDX-License-Identifier: BSL-1.0
+/*!
+ * Detect and find the ldc command.
+ */
+module battery.detect.ldc;
+
+import core.exception;
+
+import watt = [
+	watt.io.file,
+	watt.text.ascii,
+	watt.text.string,
+	watt.text.sink,
+	watt.process];
+import semver = watt.text.semver;
+
+import battery.defines;
+import battery.util.path;
+
+static import battery.util.log;
+
+
+/*!
+ * Used as an argument when supplying a command on the command line.
+ */
+struct FromArgs
+{
+	cmd: string;     //!< The path to the command.
+	args: string[];  //!< The arguments to supply to the command.
+}
+
+/*!
+ * The result of the detection.
+ */
+struct Result
+{
+	ver: semver.Release;  //!< If non-null the version of the command.
+	from: string;         //!< Either "path", "args", "conf", or null.
+
+	cmd: string;          //!< The path to the command.
+	args: string[];       //!< The arguments to supply to the command.
+}
+
+/*!
+ * Find LDC commands from the environment via PATH.
+ *
+ * @Param path If non-null, the value of the PATH environment variable.
+ * @Param results After call, will contain found commands (if any).
+ * @Returns `false` if no results were found.
+ */
+fn detectFromPath(path: string, out results: Result[]) bool
+{
+	res: Result;
+	log.info("Detecting LDC from path.");
+
+	if (fromPath(path, out res)) {
+		results ~= res;
+		res.dump("Found");
+	}
+
+	return results.length != 0;
+}
+
+/*!
+ * Validate LDC command given to us via arguments.
+ *
+ * @Param arg The LDC command given via the arguments.
+ * @Param result Will be filled out with the details from `arg` on success.
+ * @Returns `false` if the arguments didn't have an LDC command or it could not be found.
+ */
+fn detectFromArgs(ref arg: FromArgs, out result: Result) bool
+{
+	if (arg.cmd is null) {
+		return false;
+	}
+
+	log.info("Checking LDC from args.");
+
+	if (!checkArgCmd(ref log, arg.cmd, "ldc")) {
+		return false;
+	}
+
+	result.ver = getVersionFromLdc(arg.cmd);
+	if (result.ver is null) {
+		return false;
+	}
+
+	result.from = "args";
+	result.cmd = arg.cmd;
+	result.args = arg.args;
+	result.dump("Found");
+	return true;
+}
+
+/*!
+ * Validate LDC command given to us via battery config.
+ *
+ * @Param batConf The battery config to check.
+ * @Param result Filled in with the command from `batConf` on success.
+ * @Returns `false` if batConf didn't contain an LDC command, or it couldn't be found.
+ */
+fn detectFromBatConf(ref batConf: BatteryConfig, out result: Result) bool
+{
+	if (batConf.ldcCmd is null) {
+		return false;
+	}
+
+	log.info(new "Checking LDC from '${batConf.filename}'.");
+
+	if (!checkArgCmd(ref log, batConf.ldcCmd, "ldc")) {
+		return false;
+	}
+
+	result.ver = getVersionFromLdc(batConf.ldcCmd);
+	if (result.ver is null) {
+		return false;
+	}
+
+	result.from = "conf";
+	result.cmd = batConf.ldcCmd;
+	result.dump("Found");
+	return true;
+}
+
+/*!
+ * Add needed arguments to a Result.
+ * Added arguments are added before any arguments present in the input Result.
+ * 
+ * @Param from The input result.
+ * @Param arch The target architecture.
+ * @Param platform The target platform.
+ * @Param res The output result.
+ */
+fn addArgs(ref from: Result, arch: Arch, platform: Platform, out res: Result)
+{
+	res.from = from.from;
+	res.cmd = from.cmd;
+	if (target := getTargetString(arch)) {
+		res.args = [target] ~ from.args;
+	}
+}
+
+private:
+
+/*!
+ * So we get the right prefix on log messages.
+ */	
+global log: battery.util.log.Logger = {"detect.ldc"};
+
+fn dump(ref res: Result, message: string)
+{
+	ss: watt.StringSink;
+
+	ss.sink(message);
+	watt.format(ss.sink, "\n\tver = %s", res.ver);
+	watt.format(ss.sink, "\n\tfrom = %s", res.from);
+	watt.format(ss.sink, "\n\tcmd = %s", res.cmd);
+	watt.format(ss.sink, "\n\targs = [");
+	foreach (arg; res.args) {
+		ss.sink("\n\t\t");
+		ss.sink(arg);
+	}
+	ss.sink("]");
+
+	log.info(ss.toString());
+}
+
+fn fromPath(path: string, out res: Result) bool
+{
+	res.cmd = searchPath(path, "ldc2");
+	if (res.cmd is null) {
+		log.info("Failed to find 'ldc2' oon path.");
+	}
+
+	res.ver = getVersionFromLdc(res.cmd);
+	if (res.ver is null) {
+		return false;
+	}
+
+	res.from = "path";
+	log.info(new "Found ldc '${res.cmd}'");
+	return true;
+}
+
+/*!
+ * Get a flag that outputs the target arch.
+ */
+fn getTargetString(arch: Arch) string
+{
+	final switch (arch) with (Arch) {
+	case X86: return "--march=x86";
+	case X86_64: return "--march=x86-64";
+	case ARMHF: assert(false);
+	case AArch64: return "--march=aarch64";
+	}
+}
+
+fn getVersionFromLdc(cmd: string) semver.Release
+{
+	ldcOutput: string;
+	line: string;
+	ldcRetval: u32;
+	ret: semver.Release;
+	
+	try {
+		ldcOutput = watt.getOutput(cmd, ["-v"], ref ldcRetval);
+
+		line = extractLdcVersionString(ldcOutput);
+		if (line is null) {
+			log.info("Couldn't extract LDC version.");
+			return null;
+		}
+
+		ret = new semver.Release(line);
+	} catch (watt.ProcessException e) {
+		log.info(new "Failed to run '${cmd}'\n\t${e.msg}");
+	} catch (Exception e) {
+		log.info(new "Failed to parse output from '${cmd}' '${line}'\n\tf${e.msg}");
+	}
+
+	return ret;
+}
+
+/*!
+ * Extracts a version string from the output of "ldc2 -v".
+ *
+ * At time of writing, ldc2's -v output was as follows:
+ * $ ldc2 -v
+ * binary    /opt/homebrew/Cellar/ldc/1.38.0/bin/ldc2
+ * version   1.38.0 (DMD v2.108.1, LLVM 18.1.6)
+ * config    /opt/homebrew/Cellar/ldc/1.38.0/etc/ldc2.conf (arm64-apple-darwin23.5.0)
+ * Error: No source files
+ *
+ * extractLdcVersionString, given the above output, should return "1.38.0".
+ */
+
+enum VersionLineStart = "version";
+
+fn extractLdcVersionString(output: string) string
+{
+	line: string;
+
+	foreach (l; watt.splitLines(watt.strip(output))) {
+		if (watt.startsWith(l, VersionLineStart)) {
+			line = l;
+			break;
+		}
+	}
+
+	// We did not find any version line.
+	if (line is null || line.length <= VersionLineStart.length) {
+		return null;
+	}
+
+	// Remove the "version" from the start.
+	line = line[VersionLineStart.length .. $];
+	line = watt.stripLeft(line);
+	
+	// At this point we should be at the start of the version string.
+	if (line.length == 0 || !watt.isDigit(line[0])) {
+		return null;
+	}
+
+	// Get the index of the character one past the end of the version string.
+	endIndex := watt.indexOf(line, ' ');
+	if (endIndex == -1) {
+		return null;
+	}
+
+	return line[0 .. endIndex];
+}

--- a/lib/src/battery/detect/llvm/package.volt
+++ b/lib/src/battery/detect/llvm/package.volt
@@ -384,7 +384,7 @@ fn getLLVMTargetString(arch: Arch, platform: Platform) string
 		case X86: return "i386-apple-macosx10.9.0";
 		case X86_64: return "x86_64-apple-macosx10.9.0";
 		case ARMHF: return null;
-		case AArch64: return null;
+		case AArch64: return "aarch64-apple-macosx10.9.0";
 		}
 	case Linux:
 		final switch (arch) with (Arch) {

--- a/sources.mk
+++ b/sources.mk
@@ -1,12 +1,19 @@
 
 SRC=\
+	src/battery/backend/*.volt \
 	src/battery/frontend/*.volt \
+	src/battery/interfaces/*.volt \
 	src/battery/testing/output/*.volt \
 	src/battery/testing/*.volt \
-	src/battery/backend/*.volt \
 	src/battery/policy/*.volt \
 	src/battery/util/*.volt \
 	src/battery/*.volt \
-	src/build/core/*.volt \
-	src/build/util/*.volt \
-	src/*.volt
+	src/*.volt \
+	lib/src/battery/conf/*.volt \
+	lib/src/battery/detect/llvm/*.volt \
+	lib/src/battery/detect/msvc/*.volt \
+	lib/src/battery/detect/*.volt \
+	lib/src/battery/util/*.volt \
+	lib/src/battery/*.volt \
+	lib/src/build/core/*.volt \
+	lib/src/build/util/*.volt

--- a/src/battery/backend/builder.volt
+++ b/src/battery/backend/builder.volt
@@ -473,6 +473,13 @@ public:
 				"-o",
 				name
 			];
+		} else if (gen.config.ldcCmd !is null) {
+			c = gen.config.ldcCmd;
+			kind = ArgsKind.Ldc;
+
+			args = c.args ~ [
+				"--of=" ~ name
+			];
 		} else if (gen.config.rdmdCmd !is null) {
 			c = gen.config.rdmdCmd;
 			kind = ArgsKind.Dmd;
@@ -492,7 +499,7 @@ public:
 		fn doScan(p: Project) string[] {
 			found := deepScan(p.srcDir, ".d");
 			files ~= found;
-			if (kind == ArgsKind.Gdc) {
+			if (kind == ArgsKind.Gdc || kind == ArgsKind.Ldc) {
 				return found;
 			} else {
 				return null;

--- a/src/battery/backend/command.volt
+++ b/src/battery/backend/command.volt
@@ -29,6 +29,7 @@ public:
 		LinkLink      = 0x040,
 		Dmd           = 0x080,
 		Gdc           = 0x100,
+		Ldc           = 0x200,
 
 		AnyLdLink     = VoltaLink | ClangLink | Gdc,
 		AnyLink       = VoltaLink | ClangLink | LinkLink,
@@ -192,6 +193,30 @@ public:
 				}
 			}
 
+			if (kind & Kind.Ldc) {
+				ret ~= ["-I", b.srcDir];
+
+				foreach (def; b.defs) {
+					ret ~= new "--d-version=${def}";
+				}
+
+				foreach (path; b.frameworkPaths) {
+					ret ~= new "-L-F${path}";
+				}
+
+				foreach (framework; b.frameworks) {
+					ret ~= new "-L-framework ${framework}";
+				}
+
+				foreach (path; b.libPaths) {
+					ret ~= new "-L-L${path}";
+				}
+
+				foreach (l; b.libs) {
+					ret ~= new "-L-l${l}";
+				}
+			}
+
 			// Shared with clang and volta.
 			if (kind & Kind.AnyLdLink) {
 				foreach (path; b.frameworkPaths) {
@@ -285,7 +310,7 @@ public:
 
 		traverse(base);
 
-		if (!(kind & Kind.Dmd || kind & Kind.Gdc)) {
+		if (!(kind & Kind.Dmd || kind & Kind.Gdc || kind & Kind.Ldc)) {
 			// Implictly add rt as a dependancy
 			traverse(rt);
 		}

--- a/src/battery/driver.volt
+++ b/src/battery/driver.volt
@@ -627,6 +627,7 @@ in your system.
 		hasRtDir: bool;
 		hasRdmdTool := mBootstrapConfig !is null && mBootstrapConfig.getTool(RdmdName) !is null;
 		hasGdcTool := mBootstrapConfig !is null && mBootstrapConfig.getTool(GdcName) !is null;
+		hasLdcTool := mBootstrapConfig !is null && mBootstrapConfig.getTool(LdcName) !is null;
 		hasVoltaDir := mStore.get("volta", null) !is null;
 		hasVoltaTool := mConfig.getTool(VoltaName) !is null;
 
@@ -640,8 +641,8 @@ in your system.
 		if (!hasVoltaDir && !hasVoltaTool) {
 			abort("Must specify a Volta directory or --cmd-volta (for now).");
 		}
-		if (!hasGdcTool && !hasRdmdTool && !hasVoltaTool) {
-			abort("No rdmd or gdc found (needed right now for Volta).");
+		if (!hasGdcTool && !hasRdmdTool && !hasLdcTool && !hasVoltaTool) {
+			abort("No rdmd, gdc, or ldc found (needed right now for Volta).");
 		}
 		if (!hasRtDir) {
 			abort("Must specify a Volta rt directory (for now).");

--- a/src/battery/frontend/github.volt
+++ b/src/battery/frontend/github.volt
@@ -6,7 +6,7 @@
 module battery.frontend.github;
 
 import watt.text.string;
-import battery.commonInterfaces;
+import battery.interfaces;
 
 
 class Repo

--- a/src/battery/interfaces/configuration.volt
+++ b/src/battery/interfaces/configuration.volt
@@ -69,6 +69,9 @@ public:
 	//! Gdc for bootstrapping.
 	gdcCmd: Command;
 
+	//! LDC for bootstrapping.
+	ldcCmd: Command;
+
 	//! All added tools.
 	tools: Command[string];
 

--- a/src/battery/policy/tools.volt
+++ b/src/battery/policy/tools.volt
@@ -1,4 +1,4 @@
-// Copyright 2015-2018, Jakob Bornecrantz.
+// Copyright 2015-2024, Jakob Bornecrantz.
 // SPDX-License-Identifier: BSL-1.0
 module battery.policy.tools;
 
@@ -9,6 +9,7 @@ import llvmVersion = battery.frontend.llvmVersion;
 
 enum VoltaName = "volta";
 enum GdcName = "gdc";
+enum LdcName = "ldc";
 enum NasmName = "nasm";
 enum RdmdName = "rdmd";
 enum CLName = "cl";
@@ -38,6 +39,7 @@ enum VoltaPrint =      "  VOLTA    ";
 enum NasmPrint =       "  NASM     ";
 enum RdmdPrint =       "  RDMD     ";
 enum GdcPrint =        "  GDC      ";
+enum LdcPrint =        "  LDC      ";
 enum LinkPrint =       "  LINK     ";
 enum CLPrint   =       "  CL       ";
 enum LLVMConfigPrint = "  LLVM-CONFIG  ";
@@ -52,6 +54,7 @@ enum HostGdcPrint =    "  HOSTGDC  ";
 
 enum BootRdmdPrint =   "  BOOTRDMD ";
 enum BootGdcPrint =    "  BOOTGDC  ";
+enum BootLdcPrint =    "  BOOTLDC  ";
 
 
 /*


### PR DESCRIPTION
Add LDC and macOS aarch64 support 

LDC (ldc2, technically) is the most accessible D compiler available to Apple Silicon, being in Homebrew. GDC isn't present, and DMD is Intel only.

There's also a little aarch64 stuff, and fixing the GNUMakefile for bootstrapping.